### PR TITLE
Fix alignment value for Aligned512M.

### DIFF
--- a/src/align.rs
+++ b/src/align.rs
@@ -95,7 +95,7 @@ impl_align! {
     struct align(0x4000000)  Aligned64M;  "A thin wrapper type with an alignment of at least 64 MB."
     struct align(0x8000000)  Aligned128M; "A thin wrapper type with an alignment of at least 128 MB."
     struct align(0x10000000) Aligned256M; "A thin wrapper type with an alignment of at least 256 MB."
-    struct align(0x10000000) Aligned512M; "A thin wrapper type with an alignment of at least 512 MB."
+    struct align(0x20000000) Aligned512M; "A thin wrapper type with an alignment of at least 512 MB."
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Simple update to the alignment parameter for the generated `Aligned512M` struct.